### PR TITLE
Fix WebSocketProvider closure and improve RpcService encapsulation

### DIFF
--- a/mev-bot-v10/src/core/MevBotV10Orchestrator.ts
+++ b/mev-bot-v10/src/core/MevBotV10Orchestrator.ts
@@ -295,8 +295,7 @@ export class MevBotV10Orchestrator {
         // In a more robust app, clear the interval timer here.
 
         // Close any other persistent connections (e.g., RPC WebSocket providers if kept open)
-        this.rpcService.getWebSocketProvider('mainnet')?.terminate(); // Example for ethers v5 specific method
-        // this.rpcService.closeAllWebSockets(); // If such a method exists in RpcService
+        this.rpcService.closeAllWebSocketProviders();
 
         logger.info("MevBotV10Orchestrator: Stopped.");
     }

--- a/mev-bot-v10/src/core/rpc/rpcService.ts
+++ b/mev-bot-v10/src/core/rpc/rpcService.ts
@@ -193,4 +193,21 @@ export class RpcService {
         }
         return null; // Should not be reached if retries > 0
     }
+
+    public closeAllWebSocketProviders(): void {
+        logger.info("RpcService: Attempting to close all active WebSocket providers...");
+        this.webSocketProviders.forEach((provider, network) => {
+            try {
+                if (provider && provider._websocket) {
+                    logger.info(`RpcService: Closing WebSocket provider for network: ${network}`);
+                    provider.removeAllListeners(); // Clean up any direct listeners on the provider itself
+                    provider._websocket.close(1000, "RpcService shutting down all WebSockets");
+                }
+            } catch (e) {
+                logger.error({ err: e, network }, `RpcService: Error closing WebSocket provider for ${network}.`);
+            }
+        });
+        this.webSocketProviders.clear(); // Clear the map
+        logger.info("RpcService: All WebSocket providers closure attempts finished and map cleared.");
+    }
 }


### PR DESCRIPTION
- I corrected the method for closing ethers.v5 WebSocketProvider in MevBotV10Orchestrator's stop() method, resolving a TypeScript error where 'terminate' was called on a WebSocketProvider.
- I added a `closeAllWebSocketProviders()` method to `RpcService.ts` to properly manage the lifecycle and closure of its WebSocket provider instances.
- I updated `MevBotV10Orchestrator.ts` to use the new `RpcService.closeAllWebSocketProviders()` method for a cleaner shutdown sequence.