### PR TITLE
I've fixed the SignatureLike type and attempted to resolve the persis…

### DIFF
--- a/mev-bot-v10/src/core/kms/kmsService.ts
+++ b/mev-bot-v10/src/core/kms/kmsService.ts
@@ -1,5 +1,6 @@
 import { KeyManagementServiceClient, protos } from '@google-cloud/kms';
-import { ethers, utils as ethersUtils, providers, BigNumber, Signature } from 'ethers'; // Removed SignatureLike from root
+import { ethers, utils as ethersUtils, providers, BigNumber } from 'ethers'; // Removed Signature and SignatureLike from root
+import { SignatureLike } from 'ethers/lib/utils'; // Deep import for SignatureLike
 import { ConfigService } from '../config/configService'; // Adjust path
 import { getLogger } from '../logger/loggerService'; // Adjust path
 // elliptic is a good library for EC operations, including signature parsing and public key recovery
@@ -100,7 +101,7 @@ export class KmsService {
         }
     }
 
-    public async signTransactionDigest(digestHex: string): Promise<Signature | null> {
+    public async signTransactionDigest(digestHex: string): Promise<SignatureLike | null> { // Updated return type
         const digestBuffer = Buffer.from(digestHex.slice(2), 'hex');
         logger.debug(`KmsService: Signing digest ${digestHex} for key ${this.keyPath}`);
 
@@ -151,7 +152,7 @@ export class KmsService {
             }
 
             // ethers.Signature object
-            const ethersSignature: ethersUtils.SignatureLike = { // Changed to ethersUtils.SignatureLike
+            const ethersSignature: SignatureLike = { // Use directly imported SignatureLike
                 r: r.toHexString(),
                 s: s.toHexString(),
                 recoveryParam: recoveryParam,


### PR DESCRIPTION
…tent nonce error in KmsService.

- I corrected the SignatureLike import and usage in `kmsService.ts` by importing directly from 'ethers/lib/utils'. This should resolve TS2694/TS2724 for SignatureLike.
- I re-verified and ensured the logic to convert `transactionRequest.nonce` to a JavaScript number within a cleaned `transactionFieldsForSigning` object before passing it to `ethersUtils.serializeTransaction`.

Note: Despite my efforts to normalize the 'nonce' field to a number, you've indicated that the TS2345 error ('Argument of type TransactionRequest is not assignable to parameter of type UnsignedTransaction' due to nonce incompatibility) may still persist. The object passed to serializeTransaction might require further refinement to strictly match the internal UnsignedTransaction type expected by ethers.utils.serializeTransaction in v5.