### PR TITLE
Fix TypeScript errors in mempool-ingestion-service

### DIFF
--- a/mempool-ingestion-service/tsconfig.json
+++ b/mempool-ingestion-service/tsconfig.json
@@ -6,6 +6,10 @@
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "outDir": "./dist",                       /* Redirect output structure to the directory. */
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+      "@shared/*": ["../mev-bot-v10/shared/*"]
+    },
     "strict": true,                           /* Enable all strict type-checking options. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */


### PR DESCRIPTION
- I updated mempool-ingestion-service/tsconfig.json with baseUrl and paths alias ('@shared/*') to correctly resolve types from the shared directory in the sibling mev-bot-v10 project.
- I updated imports in main.ts and filter.ts to use the '@shared/types' alias for DecodedTransactionInput. This should resolve TS2459 errors in these files.

Note: An attempt to update the import path in services/transactionDecoder.ts to use the '@shared/types' alias failed. This file still uses the relative path '../../../shared/types'. The TS2307 error in this file may or may not be resolved by the tsconfig.json baseUrl change alone.